### PR TITLE
fix: add missing command to Dockerfile

### DIFF
--- a/lessons/more-complicated-nodejs-app.md
+++ b/lessons/more-complicated-nodejs-app.md
@@ -60,6 +60,8 @@ FROM node:12-stretch
 
 USER node
 
+RUN mkdir /home/node/code
+
 WORKDIR /home/node/code
 
 COPY --chown=node:node . .


### PR DESCRIPTION
Add missing command to Dockerfile in the "A More Complicated Node.js App" section.
This command will solve the permissions issue that might happen during the container building.