### PR TITLE
refactor: version 8 (latest) of node-sass does not work with the used Docker container

### DIFF
--- a/lessons/static-assets-project.md
+++ b/lessons/static-assets-project.md
@@ -14,7 +14,7 @@ We're going to create a new project using [create-react-app][cra]. Go to the dir
 
 This will scaffold out a whole new TypeScript React project for you.
 
-**OPTIONAL:** Go into the project and run `npm install node-sass`. This will install the Sass compiler for you. Go change both of the `.css` files in this project to have the `.scss` extensions (everything that's valid in CSS is valid in SCSS.) Update the two `.css` imports in `App.tsx` and `index.tsx` to have `.scss imports instead. If you're struggling with the Sass stuff, feel free to leave it out and just go with an out-of-the-box CRA app, the Sass stuff is just to drive home the point that you can have as many dependencies as you want.
+**OPTIONAL:** Go into the project and run `npm install node-sass@7.0.3`. This will install the Sass compiler for you. Go change both of the `.css` files in this project to have the `.scss` extensions (everything that's valid in CSS is valid in SCSS.) Update the two `.css` imports in `App.tsx` and `index.tsx` to have `.scss imports instead. If you're struggling with the Sass stuff, feel free to leave it out and just go with an out-of-the-box CRA app, the Sass stuff is just to drive home the point that you can have as many dependencies as you want.
 
 To make sure this works right now, run `npm run start` in your console and make sure the app starts okay. You should see a splash screen. Once you're ready to build it, run `npm run build` to have it build for production.
 


### PR DESCRIPTION
I was following the class and noticed that `node-sass` v8 was released recently. This will require a higher python version inside the `node:12-stretch` container because of `node-gyp`, so it wont be able to build according to what is been told in the class. Installing a specific version for node-sass `@7.0.3` fixes the issue.

```
#8 14.93 gyp verb find Python - executing "python3" to get executable path
#8 14.96 gyp verb find Python - executable path is "/usr/bin/python3"
#8 14.96 gyp verb find Python - executing "/usr/bin/python3" to get version
#8 14.97 gyp verb find Python - version is "3.5.3"
#8 14.97 gyp verb find Python - version is 3.5.3 - should be >=3.6.0
#8 14.97 gyp verb find Python - THIS VERSION OF PYTHON IS NOT SUPPORTED
#8 14.97 gyp verb find Python checking if "python" can be used
#8 14.97 gyp verb find Python - executing "python" to get executable path
#8 14.98 gyp verb find Python - executable path is "/usr/bin/python"
#8 14.98 gyp verb find Python - executing "/usr/bin/python" to get version
#8 14.99 gyp verb find Python - version is "2.7.13"
#8 14.99 gyp verb find Python - version is 2.7.13 - should be >=3.6.0
#8 14.99 gyp verb find Python - THIS VERSION OF PYTHON IS NOT SUPPORTED
#8 14.99 gyp ERR! find Python
#8 14.99 gyp ERR! find Python Python is not set from command line or npm configuration
#8 14.99 gyp ERR! find Python Python is not set from environment variable PYTHON
#8 14.99 gyp ERR! find Python checking if "python3" can be used
#8 14.99 gyp ERR! find Python - executable path is "/usr/bin/python3"
#8 14.99 gyp ERR! find Python - version is "3.5.3"
#8 14.99 gyp ERR! find Python - version is 3.5.3 - should be >=3.6.0
#8 14.99 gyp ERR! find Python - THIS VERSION OF PYTHON IS NOT SUPPORTED
#8 14.99 gyp ERR! find Python checking if "python" can be used
#8 14.99 gyp ERR! find Python - executable path is "/usr/bin/python"
#8 14.99 gyp ERR! find Python - version is "2.7.13"
#8 14.99 gyp ERR! find Python - version is 2.7.13 - should be >=3.6.0
#8 14.99 gyp ERR! find Python - THIS VERSION OF PYTHON IS NOT SUPPORTED
#8 14.99 gyp ERR! find Python
#8 14.99 gyp ERR! find Python **********************************************************
#8 14.99 gyp ERR! find Python You need to install the latest version of Python.
#8 14.99 gyp ERR! find Python Node-gyp should be able to find and use Python. If not,
#8 14.99 gyp ERR! find Python you can try one of the following options:
#8 14.99 gyp ERR! find Python - Use the switch --python="/path/to/pythonexecutable"
#8 14.99 gyp ERR! find Python   (accepted by both node-gyp and npm)
#8 14.99 gyp ERR! find Python - Set the environment variable PYTHON
#8 14.99 gyp ERR! find Python - Set the npm configuration variable python:
#8 14.99 gyp ERR! find Python   npm config set python "/path/to/pythonexecutable"
#8 14.99 gyp ERR! find Python For more information consult the documentation at:
#8 14.99 gyp ERR! find Python https://github.com/nodejs/node-gyp#installation
#8 14.99 gyp ERR! find Python **********************************************************
```