### PR TITLE
Added node version in Docker-Docker CLI -> inspect section

### DIFF
--- a/lessons/docker-cli.md
+++ b/lessons/docker-cli.md
@@ -24,7 +24,7 @@ That will pull the hollywood container from the user jturpin's user account. The
 ### inspect
 
 ```bash
-docker inspect node
+docker inspect node:12-stretch
 ```
 
 This will dump out a lot of info about the container. Helpful when figuring out what's going on with a container


### PR DESCRIPTION
## Fixed node version in a command
In Docker -> 6. Docker CLI in the "inspect" section node version 12-stretch was missing, 